### PR TITLE
Generic text row field or conditional field can't be used on Tabs values

### DIFF
--- a/theme.inc
+++ b/theme.inc
@@ -128,7 +128,7 @@ function template_preprocess_views_bootstrap_tab_plugin_style(&$vars) {
   // Get tabs.
   if (isset($view->field[$tab_field])) {
     foreach (array_keys($vars['rows']) as $key) {
-      $vars['tabs'][$key] = $view->style_plugin->get_field_value($key, $tab_field);
+      $vars['tabs'][$key] = $view->style_plugin->get_field($key, $tab_field);
     }
   }
 


### PR DESCRIPTION
Needs review. Based on https://www.drupal.org/project/views_bootstrap/issues/2742547#comment-12607711