### PR TITLE
Proof of concept for conditionally loading bootstrap assets when plugins used

### DIFF
--- a/config/views_bootstrap.settings.json
+++ b/config/views_bootstrap.settings.json
@@ -1,5 +1,4 @@
 {
     "_config_name": "views_bootstrap.settings",
-    "views_bootstrap_visibility": "",
-    "views_bootstrap_pages": ""
+    "include_bootstrap_assets": false
 }

--- a/theme.inc
+++ b/theme.inc
@@ -4,6 +4,8 @@
  * Implementation of template preprocess for the view.
  */
 function template_preprocess_views_bootstrap_accordion_plugin_style(&$vars) {
+  _views_bootstrap_include_bootstrap_assets();
+
   $view = &$vars['view'];
   $title_field = $vars['options']['title_field'];
 
@@ -21,6 +23,8 @@ function template_preprocess_views_bootstrap_accordion_plugin_style(&$vars) {
  * Implementation of template preprocess for the view.
  */
 function template_preprocess_views_bootstrap_carousel_plugin_style(&$vars) {
+  _views_bootstrap_include_bootstrap_assets();
+
   backdrop_add_js(array(
     'viewsBootstrap' => array(
       'carousel' => array(
@@ -65,6 +69,8 @@ function template_preprocess_views_bootstrap_carousel_plugin_rows(&$vars) {
  * Implementation of template preprocess for the view.
  */
 function template_preprocess_views_bootstrap_grid_plugin_style(&$vars) {
+  _views_bootstrap_include_bootstrap_assets();
+
   $view     = $vars['view'];
   $options  = $view->style_plugin->options;
   $horizontal = ($options['alignment'] === 'horizontal');
@@ -82,6 +88,8 @@ function template_preprocess_views_bootstrap_grid_plugin_style(&$vars) {
  * Implementation of template preprocess for the view.
  */
 function template_preprocess_views_bootstrap_list_group_plugin_style(&$vars) {
+  _views_bootstrap_include_bootstrap_assets();
+
   $view = $vars['view'];
   $link_field = $vars['options']['link_field'];
 
@@ -97,6 +105,8 @@ function template_preprocess_views_bootstrap_list_group_plugin_style(&$vars) {
  * Implementation of template preprocess for the view.
  */
 function template_preprocess_views_bootstrap_media_plugin_style(&$vars) {
+  _views_bootstrap_include_bootstrap_assets();
+
   $view = &$vars['view'];
 
   $image_field = $vars['options']['image_field'];
@@ -119,6 +129,8 @@ function template_preprocess_views_bootstrap_media_plugin_style(&$vars) {
  * Implementation of template preprocess for the view.
  */
 function template_preprocess_views_bootstrap_tab_plugin_style(&$vars) {
+  _views_bootstrap_include_bootstrap_assets();
+
   $view = &$vars['view'];
   $tab_field = $vars['options']['tab_field'];
 
@@ -142,6 +154,8 @@ function template_preprocess_views_bootstrap_tab_plugin_style(&$vars) {
  * Implementation of template preprocess for the view.
  */
 function template_preprocess_views_bootstrap_table_plugin_style(&$vars) {
+  _views_bootstrap_include_bootstrap_assets();
+
   template_preprocess_views_view_table($vars);
 
   $vars['responsive'] = $vars['options']['responsive'];
@@ -158,6 +172,8 @@ function template_preprocess_views_bootstrap_table_plugin_style(&$vars) {
  * Implementation of template preprocess for the view.
  */
 function template_preprocess_views_bootstrap_thumbnail_plugin_style(&$vars) {
+  _views_bootstrap_include_bootstrap_assets();
+
   $view     = $vars['view'];
   $options  = $view->style_plugin->options;
   $horizontal = ($options['alignment'] === 'horizontal');

--- a/views_bootstrap.admin.inc
+++ b/views_bootstrap.admin.inc
@@ -6,20 +6,18 @@
  *
  */
 function views_bootstrap_settings($form_state) {
-
-  $form['views_bootstrap_visibility'] = array(
-    '#type' => 'radios',
-    '#title' => t('If you are not using a Bootstrap based theme, you can include the Bootstrap styles and scripts on specific pages here'),
-    '#options' => array(0 => t('All pages except those listed'), 1 => t('Only the listed pages')),
-    '#default_value' => config_get('views_bootstrap.settings', 'views_bootstrap_visibility'),
+  $form = array();
+  $form['bootstrap_assets'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Bootstrap Assets'),
+    '#description' => t('Bootstrap version this setting provides: %version', array('%version' => VIEWS_BOOTSTRAP_ASSETS_VERSION)),
+    'include_bootstrap_assets' => array(
+      '#type' => 'checkbox',
+      '#title' => t('Include Bootstrap CSS & JS when used by Views'),
+      '#default_value' => config_get('views_bootstrap.settings', 'include_bootstrap_assets'),
+      '#description' => t('If your site does not use a Bootstrap based theme, then you will need to select this option for this module to work correctly. If your site theme includes Bootstrap assets, then this setting should be disabled (unchecked).'),
+    ),
   );
-  $form['views_bootstrap_pages'] = array(
-    '#type' => 'textarea',
-    '#title' => '<span class="element-invisible">' . t('Pages') . '</span>',
-    '#default_value' => config_get('views_bootstrap.settings', 'views_bootstrap_pages'),
-    '#description' => t("Specify pages by using their paths. Enter one path per line. The '*' character is a wildcard. Example paths are %blog for the blog page and %blog-wildcard for every personal blog. %front is the front page.", array('%blog' => 'blog', '%blog-wildcard' => 'blog/*', '%front' => '<front>')),
-  );
-
   $form['actions']['#type'] = 'actions';
   $form['actions']['submit'] = array(
     '#type' => 'submit',
@@ -41,4 +39,3 @@ function views_bootstrap_settings_submit($form, &$form_state) {
     $config->save();
     backdrop_set_message(t('The configuration options have been saved.'));
 }
-?>

--- a/views_bootstrap.module
+++ b/views_bootstrap.module
@@ -4,6 +4,8 @@
  * Bootstrap integration.
  */
 
+define('VIEWS_BOOTSTRAP_ASSETS_VERSION', '3.3.6');
+
 /**
  * Implements hook_config_info().
  */
@@ -13,36 +15,6 @@ function views_bootstrap_config_info() {
     'group' => t('Configuration'),
   );
   return $prefixes;
-}
-
-/**
- * Implements hook_init().
- */
-function views_bootstrap_init()
-{
-  $views_bootstrap_visibility = config_get('views_bootstrap.settings', 'views_bootstrap_visibility');
-  // Compare with the internal and path alias (if any).
-  $path = backdrop_get_path_alias($_GET['q']);
-  $views_bootstrap_pages = config_get('views_bootstrap.settings', 'views_bootstrap_pages');
-
-  // if $views_bootstrap_visibility is 0, then except these pages.  if $views_bootstrap_visibility is 1, then only these pages.
-  if ($views_bootstrap_visibility > 0)
-  {
-    $page_match = backdrop_match_path($path, $views_bootstrap_pages);
-  }
-  else {
-    $page_match = !backdrop_match_path($path, $views_bootstrap_pages);
-  }
-
-   if ($page_match > 0)
-  {
-  // If we have a page match according to the admin settings, load up the Animate CSS file.
-  backdrop_add_css('https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css', array('type' => 'external', 'every_page' => TRUE, 'preprocess' => TRUE));
-
-  backdrop_add_css( backdrop_get_path('module', 'views_bootstrap') . '/css/views_bootstrap.css', array('type' => 'file', 'every_page' => TRUE, 'preprocess' => TRUE));
-
-  backdrop_add_js("https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js", array('type' => 'external', 'scope' => 'footer', 'every_page' => TRUE, 'preprocess' => TRUE));
-  }
 }
 
 /**
@@ -91,6 +63,38 @@ function views_bootstrap_menu() {
   );
 
   return $items;
+}
+
+/**
+ * Include Bootstrap CSS & JS assets if the site is configured to do so.
+ */
+function _views_bootstrap_include_bootstrap_assets() {
+  // We only want to include assets if the user says so.
+  $should_include_assets = config_get('views_bootstrap.settings', 'include_bootstrap_assets');
+
+  // We never want to include assets on admin pages.
+  $is_admin = path_is_admin(current_path());
+
+  if ($should_include_assets && !$is_admin) {
+    $version = VIEWS_BOOTSTRAP_ASSETS_VERSION;
+
+    backdrop_add_css("https://maxcdn.bootstrapcdn.com/bootstrap/{$version}/css/bootstrap.min.css", array(
+      'type' => 'external',
+      'preprocess' => FALSE,
+      // Load very early so that it's very easy for other CSS to override it.
+      'group' => CSS_SYSTEM,
+      'weight' => -1000,
+    ));
+    backdrop_add_css( backdrop_get_path('module', 'views_bootstrap') . '/css/views_bootstrap.css', array(
+      'type' => 'file',
+      'preprocess' => TRUE,
+    ));
+    backdrop_add_js("https://maxcdn.bootstrapcdn.com/bootstrap/{$version}/js/bootstrap.min.js", array(
+      'type' => 'external',
+      'scope' => 'footer',
+      'preprocess' => FALSE,
+    ));
+  }
 }
 
 /**


### PR DESCRIPTION
The purpose of this PR is one approach to #28. It removes the path-based configuration and replaces it with a single checkbox:

![screen shot 2018-12-24 at 8 40 38 am](https://user-images.githubusercontent.com/1205329/50400806-9e3f2b80-0757-11e9-9501-8ecc3309b895.png)

During each `template_preporcess_*_plugin_style()` function, it looks at the value of that checkbox, and includes bootstrap's CSS & JS if the setting is enabled.

TODO:  If you like this approach, we may want to add an update hook that enables this setting all sites that had the old path-based approach enabled.
