### PR TITLE
Add the include_bootstrap_assets setting when updating from 1.1.0 (#28)

### DIFF
--- a/views_bootstrap.install
+++ b/views_bootstrap.install
@@ -8,9 +8,9 @@
 /**
  * Add config option to include Bootstrap assets.
  */
-function views_bootstrap_update_7100() {
+function views_bootstrap_update_1100() {
   $should_include_assets = config_get('views_bootstrap.settings', 'include_bootstrap_assets');
   if ($should_include_assets === NULL) {
-     config_set('views_bootstrap.settings', 'include_bootstrap_assets', TRUE)
+     config_set('views_bootstrap.settings', 'include_bootstrap_assets', TRUE);
   }
 }

--- a/views_bootstrap.install
+++ b/views_bootstrap.install
@@ -8,9 +8,9 @@
  /**
   * Add config option to include Bootstrap assets.
   */
- function views_bootstrap_update_7100() {
-   $should_include_assets = config_get('views_bootstrap.settings', 'include_bootstrap_assets');
-   if ($should_include_assets === NULL) {
+function views_bootstrap_update_7100() {
+  $should_include_assets = config_get('views_bootstrap.settings', 'include_bootstrap_assets');
+  if ($should_include_assets === NULL) {
      config_set('views_bootstrap.settings', 'include_bootstrap_assets', TRUE)
-   }
- }
+  }
+}

--- a/views_bootstrap.install
+++ b/views_bootstrap.install
@@ -5,9 +5,9 @@
  * Install, update and uninstall functions for the Views Bootstrap module.
  */
 
- /**
-  * Add config option to include Bootstrap assets.
-  */
+/**
+ * Add config option to include Bootstrap assets.
+ */
 function views_bootstrap_update_7100() {
   $should_include_assets = config_get('views_bootstrap.settings', 'include_bootstrap_assets');
   if ($should_include_assets === NULL) {

--- a/views_bootstrap.install
+++ b/views_bootstrap.install
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the Views Bootstrap module.
+ */
+
+ /**
+  * Add config option to include Bootstrap assets.
+  */
+ function views_bootstrap_update_7100() {
+   $should_include_assets = config_get('views_bootstrap.settings', 'include_bootstrap_assets');
+   if ($should_include_assets === NULL) {
+     config_set('views_bootstrap.settings', 'include_bootstrap_assets', TRUE)
+   }
+ }


### PR DESCRIPTION
When updating from version 1.1.0, add a configuration setting to include Bootstrap assets, and enable this setting. This is required because version 1.1.0 always included these assets, but they will not be included by default in the next version. (See #28.)