### PR TITLE
Add access permission

### DIFF
--- a/views_bootstrap.module
+++ b/views_bootstrap.module
@@ -70,7 +70,7 @@ function views_bootstrap_menu() {
  */
 function views_bootstrap_permission() {
   return array(
-    'access views bootstrap settings' => array(
+    'access views_bootstrap settings' => array(
       'title' => t('Access Views Bootstrap settings'),
       'description' => t('Access Views Bootstrap settings.'),
     ),

--- a/views_bootstrap.module
+++ b/views_bootstrap.module
@@ -47,7 +47,7 @@ function views_bootstrap_views_api() {
 }
 
  /**
- * Implements hook_page_menu().
+ * Implements hook_menu().
  */
 function views_bootstrap_menu() {
   $items = array();
@@ -63,6 +63,16 @@ function views_bootstrap_menu() {
   );
 
   return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function views_bootstrap_permission() {
+  $permissions['access views_bootstrap settings'] = array(
+    'title' => t('Access views_bootstrap settings'),
+  );
+  return $permissions;
 }
 
 /**

--- a/views_bootstrap.module
+++ b/views_bootstrap.module
@@ -69,10 +69,12 @@ function views_bootstrap_menu() {
  * Implements hook_permission().
  */
 function views_bootstrap_permission() {
-  $permissions['access views_bootstrap settings'] = array(
-    'title' => t('Access views_bootstrap settings'),
+  return array(
+    'access views bootstrap settings' => array(
+      'title' => t('Access Views Bootstrap settings'),
+      'description' => t('Access Views Bootstrap settings.'),
+    ),
   );
-  return $permissions;
 }
 
 /**


### PR DESCRIPTION
Added the `'access views_bootstrap settings'` permission, which makes it possible for other admin users to be granted permission to access the configuration page.

[See this issue](https://github.com/backdrop-contrib/views_bootstrap/issues/46).